### PR TITLE
Fix JSX closing tag in PublicDebateList

### DIFF
--- a/components/PublicDebateList.tsx
+++ b/components/PublicDebateList.tsx
@@ -51,4 +51,5 @@ export default function PublicDebateList({ debates }: PublicDebateListProps) {
         ))}
       </div>
     </div>
+  );
 }


### PR DESCRIPTION
## Summary
- fix missing closing parenthesis in `PublicDebateList`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react' etc.)*


------
https://chatgpt.com/codex/tasks/task_e_6844df5129b0832f86aaa90fd0d3a4d5